### PR TITLE
Initial joint_trajectory_action implementation

### DIFF
--- a/keba_rmi_plugin/include/keba_rmi_plugin/commands_keba.h
+++ b/keba_rmi_plugin/include/keba_rmi_plugin/commands_keba.h
@@ -205,6 +205,30 @@ public:
 };
 
 /**
+ * \brief Handles any custom things needed for JointTrajectoryAction
+ *
+ * In this case, all I'm doing it adding a WaitIsFinished() to the end of the trajectory.  This makes it much simpler to
+ * tell when the trajectory is actually done.
+ */
+class KebaJtaCommandHandler : public JtaCommandHandler
+{
+public:
+  KebaJtaCommandHandler()
+  {
+    handler_name_ = "Keba JTA";
+  }
+
+  /**
+   * \brief Add a WaitIsFinished to the end of the trajectory.
+   *
+   * @param point Last point
+   * @param cmd_list Full command list
+   */
+  void processLastJtaPoint(const trajectory_msgs::JointTrajectoryPoint &point,
+                           robot_movement_interface::CommandList &cmd_list) override;
+};
+
+/**
  * \brief Class that holds all of the registered commands and some joint information.
  *
  *

--- a/keba_rmi_plugin/src/commands_keba.cpp
+++ b/keba_rmi_plugin/src/commands_keba.cpp
@@ -81,6 +81,8 @@ void KebaCommandRegister::registerCommandHandlers()
 
   this->addHandler(std::move(chtest));
 
+  this->setJtaCommandHandler<KebaJtaCommandHandler>();
+
   commands_registered_ = true;
 }
 
@@ -352,6 +354,19 @@ RobotCommandPtr KebaCommandWait::processMsg(const robot_movement_interface::Comm
   cmd_ptr->setCommand(command_str, "");
 
   return cmd_ptr;
+}
+
+void KebaJtaCommandHandler::processLastJtaPoint(const trajectory_msgs::JointTrajectoryPoint &point,
+                                                robot_movement_interface::CommandList &cmd_list)
+{
+  JtaCommandHandler::processJtaPoint(point, cmd_list);
+
+  robot_movement_interface::Command cmd;
+  cmd.command_id = getNextCommandId(cmd_list);
+  cmd.command_type = "WAIT";
+  cmd.pose_type = "IS_FINISHED";  // Can add more types later
+
+  cmd_list.commands.push_back(cmd);
 }
 
 }  // namespace keba_rmi_plugin

--- a/rmi_driver/CMakeLists.txt
+++ b/rmi_driver/CMakeLists.txt
@@ -67,6 +67,7 @@ set(SRC_FILES src/commands.cpp
               src/util.cpp
               src/rmi_config.cpp
               src/joint_trajectory_action.cpp
+              src/rmi_logger.cpp
   )
 
 add_library(rmi_driver ${SRC_FILES})

--- a/rmi_driver/CMakeLists.txt
+++ b/rmi_driver/CMakeLists.txt
@@ -66,6 +66,7 @@ set(SRC_FILES src/commands.cpp
               src/driver.cpp
               src/util.cpp
               src/rmi_config.cpp
+              src/joint_trajectory_action.cpp
   )
 
 add_library(rmi_driver ${SRC_FILES})

--- a/rmi_driver/include/rmi_driver/commands.h
+++ b/rmi_driver/include/rmi_driver/commands.h
@@ -351,6 +351,8 @@ public:
     command_register_ = commandRegister;
   }
 
+  friend std::ostream& operator<<(std::ostream& o, const CommandHandler& cmdh);
+
 protected:
   /// Pointer to the CommandRegister that owns this CommandHandler
   CommandRegister* command_register_ = nullptr;
@@ -364,11 +366,6 @@ protected:
   /// The function to call when constructed by a lambda.
   CommandHandlerFunc process_func_ = nullptr;
 };
-
-inline std::ostream& operator<<(std::ostream& o, const CommandHandler& cmdh)
-{
-  return cmdh.dump(o);
-}
 
 /**
  * \brief Processes trajectory_msgs::JointTrajectory messages and turns them into a

--- a/rmi_driver/include/rmi_driver/commands.h
+++ b/rmi_driver/include/rmi_driver/commands.h
@@ -372,20 +372,23 @@ public:
 
   virtual robot_movement_interface::CommandList processJta(const trajectory_msgs::JointTrajectory& joint_trajectory);
 
-  virtual robot_movement_interface::Command processJtaPoint(const trajectory_msgs::JointTrajectoryPoint& point);
+  virtual void processJtaPoint(const trajectory_msgs::JointTrajectoryPoint& point,
+                               robot_movement_interface::CommandList& cmd_list);
 
-  virtual robot_movement_interface::Command processFirstJtaPoint(const trajectory_msgs::JointTrajectoryPoint& point)
+  virtual void processFirstJtaPoint(const trajectory_msgs::JointTrajectoryPoint& point,
+                                    robot_movement_interface::CommandList& cmd_list)
   {
-    return processJtaPoint(point);
+    processJtaPoint(point, cmd_list);
   }
 
-  virtual robot_movement_interface::Command processLastJtaPoint(const trajectory_msgs::JointTrajectoryPoint& point)
+  virtual void processLastJtaPoint(const trajectory_msgs::JointTrajectoryPoint& point,
+                                   robot_movement_interface::CommandList& cmd_list)
   {
-    return processJtaPoint(point);
+    processJtaPoint(point, cmd_list);
   }
 
 protected:
-  std::shared_ptr<robot_movement_interface::CommandList> cmd_list_;
+  // std::shared_ptr<robot_movement_interface::CommandList> cmd_list_;
   int cmd_id_;
 };
 

--- a/rmi_driver/include/rmi_driver/commands.h
+++ b/rmi_driver/include/rmi_driver/commands.h
@@ -370,6 +370,8 @@ public:
   {
   }
 
+  uint32_t getNextCommandId(robot_movement_interface::CommandList& cmd_list);
+
   virtual robot_movement_interface::CommandList processJta(const trajectory_msgs::JointTrajectory& joint_trajectory);
 
   virtual void processJtaPoint(const trajectory_msgs::JointTrajectoryPoint& point,
@@ -483,6 +485,12 @@ public:
   virtual JtaCommandHandler* getJtaCommandHandler()
   {
     return jta_command_handler_.get();
+  }
+
+  template <typename T>
+  void setJtaCommandHandler()
+  {
+    jta_command_handler_.reset(new T);
   }
 
 protected:

--- a/rmi_driver/include/rmi_driver/commands.h
+++ b/rmi_driver/include/rmi_driver/commands.h
@@ -41,6 +41,18 @@
 
 namespace rmi_driver
 {
+struct CommandResultCodes
+{
+  enum
+  {
+    OK = 0,
+    FAILED_TO_FIND_HANDLER = 1,
+    ABORT_FAIL = 9998,
+    ABORT_OK = 9999,
+
+  };
+};
+
 /**
  * \brief Commands that will be sent to the robot controller as strings.
  *

--- a/rmi_driver/include/rmi_driver/connector.h
+++ b/rmi_driver/include/rmi_driver/connector.h
@@ -32,6 +32,7 @@
 
 #include <ros/ros.h>
 #include "rmi_driver/commands.h"
+#include "rmi_driver/rmi_logger.h"
 
 #include <robot_movement_interface/EulerFrame.h>
 #include <robot_movement_interface/Result.h>
@@ -306,6 +307,8 @@ protected:
 
   /// Connector::cmdThread() will clearCommands if it receives an error response or disconnects
   bool clear_commands_on_error_ = true;
+
+  rmi_log::RmiLogger logger_;
 };
 
 }  // namespace rmi_driver

--- a/rmi_driver/include/rmi_driver/driver.h
+++ b/rmi_driver/include/rmi_driver/driver.h
@@ -37,6 +37,7 @@
 #include "rmi_driver/connector.h"
 #include "rmi_driver/joint_trajectory_action.h"
 #include "rmi_driver/rmi_config.h"
+#include "rmi_driver/rmi_logger.h"
 
 #include <robot_movement_interface/CommandList.h>
 #include <robot_movement_interface/Result.h>
@@ -90,6 +91,8 @@ protected:
   std::thread pub_thread_;
 
   std::thread io_service_thread_;
+
+  rmi_log::RmiLogger logger_;
 
   // std::vector<CommandHandler> cmd_handlers_;  //###testing
 

--- a/rmi_driver/include/rmi_driver/driver.h
+++ b/rmi_driver/include/rmi_driver/driver.h
@@ -35,6 +35,7 @@
 
 #include "rmi_driver/commands.h"
 #include "rmi_driver/connector.h"
+#include "rmi_driver/joint_trajectory_action.h"
 #include "rmi_driver/rmi_config.h"
 
 #include <robot_movement_interface/CommandList.h>
@@ -72,6 +73,8 @@ protected:
   ros::NodeHandle nh_;
 
   std::unordered_map<int32_t, std::shared_ptr<Connector>> conn_map_;
+
+  std::unordered_map<int32_t, std::shared_ptr<JointTrajectoryAction>> jta_map_;
 
   // Connector connector_;
 

--- a/rmi_driver/include/rmi_driver/joint_trajectory_action.h
+++ b/rmi_driver/include/rmi_driver/joint_trajectory_action.h
@@ -68,7 +68,9 @@ public:
   void goalCB(JointTractoryActionServer::GoalHandle gh);
 
   /**
-   * \brief Action server cancel callback method
+   * \brief Action server cancel callback method.
+   *
+   * This method will call abortGoal if there is an active command.
    *
    * \param gh goal handle
    *
@@ -77,6 +79,14 @@ public:
 
   void subCB_CommandResult(const robot_movement_interface::ResultConstPtr &msg);
 
+  /**
+   * \brief Abort an active goal and send ABORT to the robot
+   *
+   * This method will send an ABORT command to the robot (always) and call setCanceled on the active goal (if active).
+   *
+   * @param error_code The error code to use in the result.
+   * @param error_msg The error message to use in the result.
+   */
   void abortGoal(int32_t error_code, const std::string &error_msg);
 
   void abortGoal();

--- a/rmi_driver/include/rmi_driver/joint_trajectory_action.h
+++ b/rmi_driver/include/rmi_driver/joint_trajectory_action.h
@@ -57,7 +57,7 @@ class JointTrajectoryAction
 public:
   JointTrajectoryAction(std::string ns, const std::vector<std::string> &joint_names, JtaCommandHandler *jta_handler);
 
-  void test(JointTractoryActionServer::GoalHandle &gh);
+  void newGoal(JointTractoryActionServer::GoalHandle &gh);
 
   /**
     * \brief Action server goal callback method
@@ -103,7 +103,7 @@ protected:
 
   bool has_goal_;
 
-  int cmd_id_;
+  int last_cmd_id_;
 
   std::vector<std::string> conf_joint_names_;
 

--- a/rmi_driver/include/rmi_driver/joint_trajectory_action.h
+++ b/rmi_driver/include/rmi_driver/joint_trajectory_action.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2017, Doug Smith
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ *  Created on: Nov 29, 2017
+ *      Author: Doug Smith
+ */
+
+#ifndef INCLUDE_RMI_DRIVER_JOINT_TRAJECTORY_ACTION_H_
+#define INCLUDE_RMI_DRIVER_JOINT_TRAJECTORY_ACTION_H_
+
+#include <actionlib/server/action_server.h>
+#include <ros/ros.h>
+
+#include <control_msgs/FollowJointTrajectoryAction.h>
+#include <control_msgs/FollowJointTrajectoryFeedback.h>
+#include <robot_movement_interface/CommandList.h>
+#include <robot_movement_interface/Result.h>
+#include <trajectory_msgs/JointTrajectory.h>
+
+namespace rmi_driver
+{
+typedef actionlib::ActionServer<control_msgs::FollowJointTrajectoryAction> JointTractoryActionServer;
+
+class JointTrajectoryAction
+{
+public:
+  JointTrajectoryAction();
+
+  void test(JointTractoryActionServer::GoalHandle &gh);
+
+  /**
+    * \brief Action server goal callback method
+    *
+    * \param gh goal handle
+    *
+    */
+  void goalCB(JointTractoryActionServer::GoalHandle gh);
+
+  /**
+   * \brief Action server cancel callback method
+   *
+   * \param gh goal handle
+   *
+   */
+
+  void cancelCB(JointTractoryActionServer::GoalHandle gh)
+  {
+  }
+
+  void subCB_CommandResult(const robot_movement_interface::ResultConstPtr &msg);
+
+protected:
+  ros::NodeHandle nh_;
+  /**
+     * \brief Internal action server
+     */
+  JointTractoryActionServer action_server_;
+
+  ros::Publisher pub_rmi_;
+
+  ros::Subscriber sub_rmi_;
+
+  JointTractoryActionServer::GoalHandle active_goal_;
+
+  int cmd_id_;
+};
+}  // namespace rmi_driver
+
+#endif /* INCLUDE_RMI_DRIVER_JOINT_TRAJECTORY_ACTION_H_ */

--- a/rmi_driver/include/rmi_driver/joint_trajectory_action.h
+++ b/rmi_driver/include/rmi_driver/joint_trajectory_action.h
@@ -27,6 +27,11 @@
  *      Author: Doug Smith
  */
 
+/*
+ * Sections of this code are either inspired by or taken directly from the robot_movement_interface and
+ * industrial_robot_client.
+ */
+
 #ifndef INCLUDE_RMI_DRIVER_JOINT_TRAJECTORY_ACTION_H_
 #define INCLUDE_RMI_DRIVER_JOINT_TRAJECTORY_ACTION_H_
 
@@ -46,7 +51,7 @@ typedef actionlib::ActionServer<control_msgs::FollowJointTrajectoryAction> Joint
 class JointTrajectoryAction
 {
 public:
-  JointTrajectoryAction(std::string ns);
+  JointTrajectoryAction(std::string ns, const std::vector<std::string> &joint_names);
 
   void test(JointTractoryActionServer::GoalHandle &gh);
 
@@ -64,7 +69,6 @@ public:
    * \param gh goal handle
    *
    */
-
   void cancelCB(JointTractoryActionServer::GoalHandle gh)
   {
   }
@@ -74,8 +78,8 @@ public:
 protected:
   ros::NodeHandle nh_;
   /**
-     * \brief Internal action server
-     */
+   * \brief Internal action server
+   */
   JointTractoryActionServer action_server_;
 
   ros::Publisher pub_rmi_;
@@ -85,6 +89,8 @@ protected:
   JointTractoryActionServer::GoalHandle active_goal_;
 
   int cmd_id_;
+
+  std::vector<std::string> conf_joint_names_;
 };
 }  // namespace rmi_driver
 

--- a/rmi_driver/include/rmi_driver/joint_trajectory_action.h
+++ b/rmi_driver/include/rmi_driver/joint_trajectory_action.h
@@ -46,7 +46,7 @@ typedef actionlib::ActionServer<control_msgs::FollowJointTrajectoryAction> Joint
 class JointTrajectoryAction
 {
 public:
-  JointTrajectoryAction();
+  JointTrajectoryAction(std::string ns);
 
   void test(JointTractoryActionServer::GoalHandle &gh);
 

--- a/rmi_driver/include/rmi_driver/joint_trajectory_action.h
+++ b/rmi_driver/include/rmi_driver/joint_trajectory_action.h
@@ -78,26 +78,7 @@ public:
 
   void abort(const std::string &error_msg);
 
-  template <typename Tdest, typename Tsource>
-  std::vector<Tdest> sortVectorByIndices(const std::vector<size_t> &indices, const std::vector<Tsource> &data)
-  {
-    std::vector<Tdest> ret;
-    if (data.size() == 0)
-      return ret;
-
-    if (indices.size() != data.size())
-    {
-      std::stringstream ss;
-      ss << "sortVector failed: indices.size(" << indices.size() << ") != data.size(" << data.size() << ")";
-      throw std::runtime_error(ss.str());
-    }
-
-    ret.reserve(indices.size());
-
-    std::transform(indices.begin(), indices.end(), std::back_inserter(ret), [&](size_t i) { return data[i]; });
-
-    return ret;
-  }
+  bool goalIsBusy(JointTractoryActionServer::GoalHandle &gh);
 
 protected:
   /// Must be created before the action server

--- a/rmi_driver/include/rmi_driver/joint_trajectory_action.h
+++ b/rmi_driver/include/rmi_driver/joint_trajectory_action.h
@@ -35,8 +35,9 @@
 #ifndef INCLUDE_RMI_DRIVER_JOINT_TRAJECTORY_ACTION_H_
 #define INCLUDE_RMI_DRIVER_JOINT_TRAJECTORY_ACTION_H_
 
-#include <actionlib/server/action_server.h>
 #include <ros/ros.h>
+
+#include <actionlib/server/action_server.h>
 
 #include <control_msgs/FollowJointTrajectoryAction.h>
 #include <control_msgs/FollowJointTrajectoryFeedback.h>
@@ -69,11 +70,26 @@ public:
    * \param gh goal handle
    *
    */
-  void cancelCB(JointTractoryActionServer::GoalHandle gh)
-  {
-  }
+  void cancelCB(JointTractoryActionServer::GoalHandle gh);
 
   void subCB_CommandResult(const robot_movement_interface::ResultConstPtr &msg);
+
+  template <typename T>
+  std::vector<float> sortVector(const std::vector<size_t> &indices, const std::vector<T> &data)
+  {
+    if (indices.size() != data.size())
+    {
+      std::stringstream ss;
+      ss << "sortVector failed: indices.size(" << indices.size() << ") != data.size(" << data.size() << ")";
+      throw std::runtime_error(ss.str());
+    }
+    std::vector<float> ret;
+    ret.reserve(indices.size());
+
+    std::transform(indices.begin(), indices.end(), std::back_inserter(ret), [&](size_t i) { return data[i]; });
+
+    return ret;
+  }
 
 protected:
   ros::NodeHandle nh_;

--- a/rmi_driver/include/rmi_driver/joint_trajectory_action.h
+++ b/rmi_driver/include/rmi_driver/joint_trajectory_action.h
@@ -76,7 +76,11 @@ public:
 
   void subCB_CommandResult(const robot_movement_interface::ResultConstPtr &msg);
 
-  void abort(const std::string &error_msg);
+  void abortGoal(int32_t error_code, const std::string &error_msg);
+
+  void abortGoal();
+
+  void reject(int32_t error_code, const std::string &error_msg);
 
   bool goalIsBusy(JointTractoryActionServer::GoalHandle &gh);
 
@@ -95,6 +99,8 @@ protected:
   ros::Subscriber sub_rmi_;
 
   JointTractoryActionServer::GoalHandle active_goal_;
+
+  bool has_goal_;
 
   int cmd_id_;
 

--- a/rmi_driver/include/rmi_driver/joint_trajectory_action.h
+++ b/rmi_driver/include/rmi_driver/joint_trajectory_action.h
@@ -74,8 +74,10 @@ public:
 
   void subCB_CommandResult(const robot_movement_interface::ResultConstPtr &msg);
 
-  template <typename T>
-  std::vector<float> sortVector(const std::vector<size_t> &indices, const std::vector<T> &data)
+  void abort(const std::string &error_msg);
+
+  template <typename Tdest, typename Tsource>
+  std::vector<float> sortVector(const std::vector<size_t> &indices, const std::vector<Tsource> &data)
   {
     if (indices.size() != data.size())
     {
@@ -83,7 +85,7 @@ public:
       ss << "sortVector failed: indices.size(" << indices.size() << ") != data.size(" << data.size() << ")";
       throw std::runtime_error(ss.str());
     }
-    std::vector<float> ret;
+    std::vector<Tdest> ret;
     ret.reserve(indices.size());
 
     std::transform(indices.begin(), indices.end(), std::back_inserter(ret), [&](size_t i) { return data[i]; });
@@ -97,6 +99,8 @@ protected:
    * \brief Internal action server
    */
   JointTractoryActionServer action_server_;
+
+  std::string ns_;
 
   ros::Publisher pub_rmi_;
 

--- a/rmi_driver/include/rmi_driver/joint_trajectory_action.h
+++ b/rmi_driver/include/rmi_driver/joint_trajectory_action.h
@@ -38,6 +38,7 @@
 #include <ros/ros.h>
 
 #include "rmi_driver/commands.h"
+#include "rmi_driver/rmi_logger.h"
 
 #include <actionlib/server/action_server.h>
 
@@ -107,6 +108,8 @@ protected:
   std::vector<std::string> conf_joint_names_;
 
   JtaCommandHandler *jta_handler_;
+
+  rmi_log::RmiLogger logger_;
 };
 }  // namespace rmi_driver
 

--- a/rmi_driver/include/rmi_driver/rmi_config.h
+++ b/rmi_driver/include/rmi_driver/rmi_config.h
@@ -147,6 +147,9 @@ public:
 
   /// Connector::cmdThread() will clearCommands if it receives an error response
   bool clear_commands_on_error_ = true;
+
+  /// Use the rmi_driver joint_trajectory_action handler.  If false, you'll have to run your own handler.
+  bool use_rmi_driver_jta_ = true;
 };
 
 /**

--- a/rmi_driver/include/rmi_driver/rmi_logger.h
+++ b/rmi_driver/include/rmi_driver/rmi_logger.h
@@ -38,6 +38,16 @@
 #include <sstream>
 #include <string>
 
+#include <boost/algorithm/string/replace.hpp>
+
+// I was trying to get away from using defines, but the only way to get the __FILE__ etc info is from the preprocessor.
+// Call these link member functions, logger_.DEBUG() << "blah";
+#define DEBUG() DEBUG_(__FILE__, __LINE__, __ROSCONSOLE_FUNCTION__)
+#define INFO() INFO_(__FILE__, __LINE__, __ROSCONSOLE_FUNCTION__)
+#define WARN() WARN_(__FILE__, __LINE__, __ROSCONSOLE_FUNCTION__)
+#define ERROR() ERROR_(__FILE__, __LINE__, __ROSCONSOLE_FUNCTION__)
+#define FATAL() FATAL_(__FILE__, __LINE__, __ROSCONSOLE_FUNCTION__)
+
 namespace rmi_driver
 {
 namespace rmi_log
@@ -56,6 +66,9 @@ public:
 
     DebugEx(const std::string& module, const std::string& ns, ros::console::LogLocation& loc,
             Level level = Level::Info);
+
+    DebugEx(const std::string& module, const std::string& ns, ros::console::LogLocation& loc, Level level,
+            const char* file, int line, const char* function);
 
     DebugEx(const DebugEx& other);
 
@@ -99,14 +112,6 @@ public:
     //      return *this;
     //    }
 
-    std::string getName()
-    {
-      std::string ns_name = ns_;
-      if (*ns_name.begin() == '/')
-        ns_name.erase(0, 1);
-      return module_name_ + ns_name;
-    }
-
     /*template <typename... Args>
     void print(const char* fmt, Args const&... args)
     {
@@ -119,33 +124,37 @@ public:
     std::stringstream ss_;
     Level level_;
 
+    const char* file_;
+    int line_;
+    const char* function_;
+
     int throttle_ = 0;
   };
 
 public:
-  DebugEx DEBUG()
+  DebugEx DEBUG_(const char* file = 0, int line = 0, const char* function = 0)
   {
-    return DebugEx(module_name_, ns_, log_location, Level::Debug);
+    return DebugEx(module_name_, ns_, log_location, Level::Debug, file, line, function);
   }
 
-  DebugEx INFO()
+  DebugEx INFO_(const char* file = 0, int line = 0, const char* function = 0)
   {
-    return DebugEx(module_name_, ns_, log_location, Level::Info);
+    return DebugEx(module_name_, ns_, log_location, Level::Info, file, line, function);
   }
 
-  DebugEx WARN()
+  DebugEx WARN_(const char* file = 0, int line = 0, const char* function = 0)
   {
-    return DebugEx(module_name_, ns_, log_location, Level::Warn);
+    return DebugEx(module_name_, ns_, log_location, Level::Warn, file, line, function);
   }
 
-  DebugEx ERROR()
+  DebugEx ERROR_(const char* file = 0, int line = 0, const char* function = 0)
   {
-    return DebugEx(module_name_, ns_, log_location, Level::Error);
+    return DebugEx(module_name_, ns_, log_location, Level::Error, file, line, function);
   }
 
-  DebugEx FATAL()
+  DebugEx FATAL_(const char* file = 0, int line = 0, const char* function = 0)
   {
-    return DebugEx(module_name_, ns_, log_location, Level::Error);
+    return DebugEx(module_name_, ns_, log_location, Level::Error, file, line, function);
   }
 
   void setLoggerLevel(Level level);
@@ -156,12 +165,20 @@ public:
     setLoggerLevel(Level::Fatal);
   }
 
-  std::string getName()
+  /*std::string getName()
   {
     std::string ns_name = ns_;
     if (*ns_name.begin() == '/')
       ns_name.erase(0, 1);
     return module_name_ + ns_name;
+  }*/
+
+  std::string getName()
+  {
+    // std::string ns_name = boost::replace_all_copy(ns_, "/", "");
+    // ns_name = ns_;
+    return module_name_ + ":" + ns_;
+    // return ns_name;
   }
 
 private:

--- a/rmi_driver/include/rmi_driver/rmi_logger.h
+++ b/rmi_driver/include/rmi_driver/rmi_logger.h
@@ -56,6 +56,8 @@ public:
 
     DebugEx(const DebugEx& other);
 
+    DebugEx(DebugEx&& other);
+
     ~DebugEx();
 
     template <typename T>
@@ -65,11 +67,53 @@ public:
       return *this;
     }
 
+    // this is the type of std::cout
+    typedef std::basic_ostream<char, std::char_traits<char> > CoutType;
+
+    // this is the function signature of std::endl
+    typedef CoutType& (*StandardEndLine)(CoutType&);
+
+    // define an operator<< to take in std::endl
+    //    DebugEx& operator<<(StandardEndLine manip)
+    //    {
+    //      // call the function, but we cannot return it's value
+    //      manip(ss_);
+    //
+    //      return *this;
+    //    }
+
+    DebugEx& operator<<(std::ostream& (*f)(std::ostream&))
+    {
+      f(ss_);
+      return *this;
+    }
+
+    // Doesn't really work since the state variables are created in the macro, all instances will share the same
+    // throttle
+    //    DebugEx& throttle(int rate)
+    //    {
+    //      throttle_ = rate;
+    //      return *this;
+    //    }
+
+    std::string getName()
+    {
+      return module_name_ + ns_;
+    }
+
+    /*template <typename... Args>
+    void print(const char* fmt, Args const&... args)
+    {
+      ROS_ERROR(fmt, args...);
+    }*/
+
   private:
     std::string module_name_;
     std::string ns_;
     std::stringstream ss_;
     Level level_;
+
+    int throttle_ = 0;
   };
 
 public:
@@ -89,6 +133,11 @@ public:
   }
 
   DebugEx ERROR()
+  {
+    return DebugEx(module_name_, ns_, Level::Error);
+  }
+
+  DebugEx FATAL()
   {
     return DebugEx(module_name_, ns_, Level::Error);
   }

--- a/rmi_driver/include/rmi_driver/rmi_logger.h
+++ b/rmi_driver/include/rmi_driver/rmi_logger.h
@@ -45,62 +45,31 @@ namespace rmi_log
 class RmiLogger
 {
 public:
-  RmiLogger(const std::string& module_name, const std::string& ns) : module_name_(module_name), ns_(ns)
-  {
-  }
-  ~RmiLogger()
-  {
-  }
-
   typedef ros::console::levels::Level Level;
+
+  RmiLogger(const std::string& module_name, const std::string& ns);
 
   class DebugEx
   {
-  private:
-    std::string module_name_;
-    std::string ns_;
-    std::stringstream ss_;
-    Level level_;
-
   public:
-    DebugEx(const std::string& module, const std::string& ns, Level level = Level::Info)
-      : module_name_(module), ns_(ns), level_(level)
-    {
-    }
-    DebugEx(const DebugEx& other) : module_name_(other.module_name_), ns_(other.ns_), level_(other.level_)
-    {
-    }
-    ~DebugEx()
-    {
-      std::string str = ss_.str();
-      if (!str.empty())
-      {
-        switch (level_)
-        {
-          case Level::Debug:
-            ROS_DEBUG_STREAM_NAMED(module_name_, module_name_ << ":" << ns_ << str);
-            break;
-          case Level::Info:
-            ROS_INFO_STREAM_NAMED(module_name_, module_name_ << ":" << ns_ << str);
-            break;
-          case Level::Warn:
-            ROS_WARN_STREAM_NAMED(module_name_, module_name_ << ":" << ns_ << str);
-            break;
-          case Level::Error:
-            ROS_ERROR_STREAM_NAMED(module_name_, module_name_ << ":" << ns_ << str);
-            break;
-          case Level::Fatal:
-            ROS_FATAL_STREAM_NAMED(module_name_, module_name_ << ":" << ns_ << str);
-            break;
-        }
-      }
-    }
+    DebugEx(const std::string& module, const std::string& ns, Level level = Level::Info);
+
+    DebugEx(const DebugEx& other);
+
+    ~DebugEx();
+
     template <typename T>
     DebugEx& operator<<(const T& thing_to_log)
     {
       ss_ << thing_to_log;
       return *this;
     }
+
+  private:
+    std::string module_name_;
+    std::string ns_;
+    std::stringstream ss_;
+    Level level_;
   };
 
 public:
@@ -124,22 +93,18 @@ public:
     return DebugEx(module_name_, ns_, Level::Error);
   }
 
-  void setLoggerLevel(Level level)
-  {
-    std::string log_name = std::string(ROSCONSOLE_NAME_PREFIX) + "." + module_name_;
-    if (ros::console::set_logger_level(log_name, level))
-      ros::console::notifyLoggerLevelsChanged();
-  }
+  void setLoggerLevel(Level level);
 
   void disable()
   {
-    // I can't find any other way to disable the output
+    // I can't find any other way to disable the output.  Count doesn't seem to work.
     setLoggerLevel(Level::Fatal);
   }
 
 private:
   std::string module_name_;
   std::string ns_;
+  // bool enabled_;
 };
 }
 }

--- a/rmi_driver/include/rmi_driver/rmi_logger.h
+++ b/rmi_driver/include/rmi_driver/rmi_logger.h
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2017, Doug Smith
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ *  Created on: Dec 13, 2017
+ *      Author: Doug Smith
+ */
+
+// based on https://stackoverflow.com/a/23482759
+
+#ifndef INCLUDE_RMI_DRIVER_RMI_LOGGER_H_
+#define INCLUDE_RMI_DRIVER_RMI_LOGGER_H_
+
+#include <ros/ros.h>
+
+#include <ostream>
+#include <sstream>
+#include <string>
+
+namespace rmi_driver
+{
+namespace rmi_log
+{
+class RmiLogger
+{
+public:
+  RmiLogger(const std::string& module_name, const std::string& ns) : module_name_(module_name), ns_(ns)
+  {
+  }
+  ~RmiLogger()
+  {
+  }
+
+  typedef ros::console::levels::Level Level;
+
+  class DebugEx
+  {
+  private:
+    std::string module_name_;
+    std::string ns_;
+    std::stringstream ss_;
+    Level level_;
+
+  public:
+    DebugEx(const std::string& module, const std::string& ns, Level level = Level::Info)
+      : module_name_(module), ns_(ns), level_(level)
+    {
+    }
+    DebugEx(const DebugEx& other) : module_name_(other.module_name_), ns_(other.ns_), level_(other.level_)
+    {
+    }
+    ~DebugEx()
+    {
+      std::string str = ss_.str();
+      if (!str.empty())
+      {
+        switch (level_)
+        {
+          case Level::Debug:
+            ROS_DEBUG_STREAM_NAMED(module_name_, module_name_ << ":" << ns_ << str);
+            break;
+          case Level::Info:
+            ROS_INFO_STREAM_NAMED(module_name_, module_name_ << ":" << ns_ << str);
+            break;
+          case Level::Warn:
+            ROS_WARN_STREAM_NAMED(module_name_, module_name_ << ":" << ns_ << str);
+            break;
+          case Level::Error:
+            ROS_ERROR_STREAM_NAMED(module_name_, module_name_ << ":" << ns_ << str);
+            break;
+          case Level::Fatal:
+            ROS_FATAL_STREAM_NAMED(module_name_, module_name_ << ":" << ns_ << str);
+            break;
+        }
+      }
+    }
+    template <typename T>
+    DebugEx& operator<<(const T& thing_to_log)
+    {
+      ss_ << thing_to_log;
+      return *this;
+    }
+  };
+
+public:
+  DebugEx DEBUG()
+  {
+    return DebugEx(module_name_, ns_, Level::Debug);
+  }
+
+  DebugEx INFO()
+  {
+    return DebugEx(module_name_, ns_, Level::Info);
+  }
+
+  DebugEx WARN()
+  {
+    return DebugEx(module_name_, ns_, Level::Warn);
+  }
+
+  DebugEx ERROR()
+  {
+    return DebugEx(module_name_, ns_, Level::Error);
+  }
+
+  void setLoggerLevel(Level level)
+  {
+    std::string log_name = std::string(ROSCONSOLE_NAME_PREFIX) + "." + module_name_;
+    if (ros::console::set_logger_level(log_name, level))
+      ros::console::notifyLoggerLevelsChanged();
+  }
+
+  void disable()
+  {
+    // I can't find any other way to disable the output
+    setLoggerLevel(Level::Fatal);
+  }
+
+private:
+  std::string module_name_;
+  std::string ns_;
+};
+}
+}
+
+#endif /* INCLUDE_RMI_DRIVER_RMI_LOGGER_H_ */

--- a/rmi_driver/include/rmi_driver/rmi_logger.h
+++ b/rmi_driver/include/rmi_driver/rmi_logger.h
@@ -52,7 +52,10 @@ public:
   class DebugEx
   {
   public:
-    DebugEx(const std::string& module, const std::string& ns, Level level = Level::Info);
+    ros::console::LogLocation& loc_;
+
+    DebugEx(const std::string& module, const std::string& ns, ros::console::LogLocation& loc,
+            Level level = Level::Info);
 
     DebugEx(const DebugEx& other);
 
@@ -98,7 +101,10 @@ public:
 
     std::string getName()
     {
-      return module_name_ + ns_;
+      std::string ns_name = ns_;
+      if (*ns_name.begin() == '/')
+        ns_name.erase(0, 1);
+      return module_name_ + ns_name;
     }
 
     /*template <typename... Args>
@@ -119,27 +125,27 @@ public:
 public:
   DebugEx DEBUG()
   {
-    return DebugEx(module_name_, ns_, Level::Debug);
+    return DebugEx(module_name_, ns_, log_location, Level::Debug);
   }
 
   DebugEx INFO()
   {
-    return DebugEx(module_name_, ns_, Level::Info);
+    return DebugEx(module_name_, ns_, log_location, Level::Info);
   }
 
   DebugEx WARN()
   {
-    return DebugEx(module_name_, ns_, Level::Warn);
+    return DebugEx(module_name_, ns_, log_location, Level::Warn);
   }
 
   DebugEx ERROR()
   {
-    return DebugEx(module_name_, ns_, Level::Error);
+    return DebugEx(module_name_, ns_, log_location, Level::Error);
   }
 
   DebugEx FATAL()
   {
-    return DebugEx(module_name_, ns_, Level::Error);
+    return DebugEx(module_name_, ns_, log_location, Level::Error);
   }
 
   void setLoggerLevel(Level level);
@@ -150,9 +156,19 @@ public:
     setLoggerLevel(Level::Fatal);
   }
 
+  std::string getName()
+  {
+    std::string ns_name = ns_;
+    if (*ns_name.begin() == '/')
+      ns_name.erase(0, 1);
+    return module_name_ + ns_name;
+  }
+
 private:
   std::string module_name_;
   std::string ns_;
+
+  ::ros::console::LogLocation log_location;
   // bool enabled_;
 };
 }

--- a/rmi_driver/include/rmi_driver/util.h
+++ b/rmi_driver/include/rmi_driver/util.h
@@ -77,6 +77,13 @@ std::string vecToString(const std::vector<T>& vec)
   return oss.str();
 }
 
+/**
+ * \brief set the name of a thread
+ *
+ * @param thread_hdl handle of target thead
+ * @param name new name of thread
+ * @return true if successful
+ */
 #ifdef __linux__
 inline bool setThreadName(pthread_t thread_hdl, const char* name)
 {
@@ -165,6 +172,8 @@ bool usedAndNotEqual(const std::string& sample, const std::string& msg, int* ent
  * data = {123, 456, 789}
  * sorted = {456, 789, 123}
  *
+ * \exception std::runtime_error unable to sort data
+ *
  * @param indices Indicates the order to rearrange the data by.
  * @param data The data to sort
  * @return Sorted vector.  Tsource must be able to be placed in Tdest.
@@ -185,7 +194,12 @@ std::vector<Tdest> sortVectorByIndices(const std::vector<size_t>& indices, const
 
   ret.reserve(indices.size());
 
-  std::transform(indices.begin(), indices.end(), std::back_inserter(ret), [&](size_t i) { return data[i]; });
+  std::transform(indices.begin(), indices.end(), std::back_inserter(ret), [&](size_t i) {
+    if (i > data.size())
+      throw std::runtime_error("index > data.size()");
+    else
+      return data[i];
+  });
 
   return ret;
 }

--- a/rmi_driver/include/rmi_driver/util.h
+++ b/rmi_driver/include/rmi_driver/util.h
@@ -32,6 +32,7 @@
 
 #include <ros/ros.h>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace rmi_driver
@@ -74,6 +75,39 @@ std::string vecToString(const std::vector<T>& vec)
   oss << "}";
 
   return oss.str();
+}
+
+#ifdef __linux__
+inline bool setThreadName(pthread_t thread_hdl, const char* name)
+{
+  return ::pthread_setname_np(thread_hdl, name) == 0;
+}
+#else
+inline bool setThreadName(pthread_t thread_hdl, const char* name)
+{
+  return false;
+}
+#endif
+
+inline bool setThreadName(std::thread& th, const char* name)
+{
+  return setThreadName(th.native_handle(), name);
+}
+
+inline bool setThreadName(const std::thread& th, const std::string& name)
+{
+  if (name.length() > 16)
+    return false;
+
+  return setThreadName(th, name.c_str());
+}
+
+inline bool setThreadName(const std::string& name)
+{
+  if (name.length() > 16)
+    return false;
+
+  return setThreadName(::pthread_self(), name.c_str());
 }
 
 ///@{

--- a/rmi_driver/include/rmi_driver/util.h
+++ b/rmi_driver/include/rmi_driver/util.h
@@ -117,9 +117,44 @@ bool usedAndNotEqualIdx(int entry_index, const std::vector<float>& sample, const
  * @param sample Stored sample.  Can be 1 entry like "JOINTS" or multiple entries like "JOINTS|QUATERNION"
  * @param msg The received value
  * @param entry_index Optional.  Store the index of the entry that was found.
- * @return True if the sample
+ *
+ * @return True if the message disqualifies this as a match.
  */
 bool usedAndNotEqual(const std::string& sample, const std::string& msg, int* entry_index = 0);
+
+/**
+ * \brief Sort a vector of type Tsource by a vector of indices
+ *
+ * ret[n] = data[indices[n]];
+ *
+ * indices = {1, 2, 0}
+ * data = {123, 456, 789}
+ * sorted = {456, 789, 123}
+ *
+ * @param indices Indicates the order to rearrange the data by.
+ * @param data The data to sort
+ * @return Sorted vector.  Tsource must be able to be placed in Tdest.
+ */
+template <typename Tdest, typename Tsource>
+std::vector<Tdest> sortVectorByIndices(const std::vector<size_t>& indices, const std::vector<Tsource>& data)
+{
+  std::vector<Tdest> ret;
+  if (data.size() == 0)  // data isn't used
+    return ret;
+
+  if (indices.size() != data.size())  // sizes have to be equal to sort
+  {
+    std::stringstream ss;
+    ss << "sortVector failed: indices.size(" << indices.size() << ") != data.size(" << data.size() << ")";
+    throw std::runtime_error(ss.str());
+  }
+
+  ret.reserve(indices.size());
+
+  std::transform(indices.begin(), indices.end(), std::back_inserter(ret), [&](size_t i) { return data[i]; });
+
+  return ret;
+}
 
 ///@}
 

--- a/rmi_driver/launch/rmi_driver.launch
+++ b/rmi_driver/launch/rmi_driver.launch
@@ -5,8 +5,8 @@
 
   <!-- <node name="rmi_driver" pkg="rmi_driver" type="rmi_driver_node" output="screen" /> -->
 
-  <node name="ur_joint_trajectory_action" pkg="rmi_driver" type="joint_trajectory_action.py" output="screen" />
-  <node name="ur_joint_trajectory_action2" pkg="rmi_driver" type="joint_trajectory_action2.py" output="screen" />
+  <!-- <node name="ur_joint_trajectory_action" pkg="rmi_driver" type="joint_trajectory_action.py" output="screen" />
+  <node name="ur_joint_trajectory_action2" pkg="rmi_driver" type="joint_trajectory_action2.py" output="screen" /> -->
     
   
 </launch>

--- a/rmi_driver/src/commands.cpp
+++ b/rmi_driver/src/commands.cpp
@@ -200,6 +200,11 @@ bool CommandHandler::operator==(const robot_movement_interface::Command& cmd_msg
   return true;  // If it got this far it's a match
 }
 
+std::ostream& operator<<(std::ostream& o, const CommandHandler& cmdh)
+{
+  return cmdh.dump(o);
+}
+
 std::ostream& CommandHandler::dump(std::ostream& o) const
 {
   o << "CommandHandler " << getName() << " criteria: " << std::endl;

--- a/rmi_driver/src/commands.cpp
+++ b/rmi_driver/src/commands.cpp
@@ -288,8 +288,6 @@ uint32_t JtaCommandHandler::getNextCommandId(robot_movement_interface::CommandLi
 robot_movement_interface::CommandList
 JtaCommandHandler::processJta(const trajectory_msgs::JointTrajectory& joint_trajectory)
 {
-  cmd_id_ = 0;
-
   robot_movement_interface::CommandList cmd_list;
 
   if (joint_trajectory.points.size() >= 1)
@@ -317,10 +315,8 @@ void JtaCommandHandler::processJtaPoint(const trajectory_msgs::JointTrajectoryPo
                                         robot_movement_interface::CommandList& cmd_list)
 {
   robot_movement_interface::Command cmd;
-  if (cmd_list.commands.size() > 0)
-    cmd.command_id = cmd_list.commands.back().command_id + 1;
-  else
-    cmd.command_id = 0;
+
+  cmd.command_id = getNextCommandId(cmd_list);
 
   cmd.command_type = "PTP";
   cmd.pose_type = "JOINTS";
@@ -337,6 +333,12 @@ void JtaCommandHandler::processJtaPoint(const trajectory_msgs::JointTrajectoryPo
   {
     cmd.velocity_type = "ROS";
     std::copy(point.velocities.begin(), point.velocities.end(), std::back_inserter(cmd.velocity));
+  }
+
+  if (point.effort.size() > 0)
+  {
+    cmd.effort_type = "ROS";
+    std::copy(point.effort.begin(), point.effort.end(), std::back_inserter(cmd.effort));
   }
 
   cmd_list.commands.push_back(cmd);

--- a/rmi_driver/src/commands.cpp
+++ b/rmi_driver/src/commands.cpp
@@ -277,6 +277,14 @@ RobotCommandPtr CommandHandler::processMsg(const robot_movement_interface::Comma
   return ret;
 }
 
+uint32_t JtaCommandHandler::getNextCommandId(robot_movement_interface::CommandList& cmd_list)
+{
+  if (cmd_list.commands.size() > 0)
+    return cmd_list.commands.back().command_id + 1;
+  else
+    return 0;
+}
+
 robot_movement_interface::CommandList
 JtaCommandHandler::processJta(const trajectory_msgs::JointTrajectory& joint_trajectory)
 {
@@ -299,7 +307,7 @@ JtaCommandHandler::processJta(const trajectory_msgs::JointTrajectory& joint_traj
   //                 [&](const trajectory_msgs::JointTrajectoryPoint& pt) { return processJtaPoint(pt); });
 
   if (joint_trajectory.points.size() >= 2)
-    processFirstJtaPoint(joint_trajectory.points.back(), cmd_list);
+    processLastJtaPoint(joint_trajectory.points.back(), cmd_list);
   // cmd_list.commands.emplace_back(processLastJtaPoint(joint_trajectory.points.back()));
 
   return cmd_list;
@@ -309,7 +317,11 @@ void JtaCommandHandler::processJtaPoint(const trajectory_msgs::JointTrajectoryPo
                                         robot_movement_interface::CommandList& cmd_list)
 {
   robot_movement_interface::Command cmd;
-  cmd.command_id = cmd_id_++;
+  if (cmd_list.commands.size() > 0)
+    cmd.command_id = cmd_list.commands.back().command_id + 1;
+  else
+    cmd.command_id = 0;
+
   cmd.command_type = "PTP";
   cmd.pose_type = "JOINTS";
 

--- a/rmi_driver/src/commands.cpp
+++ b/rmi_driver/src/commands.cpp
@@ -295,6 +295,7 @@ JtaCommandHandler::processJta(const trajectory_msgs::JointTrajectory& joint_traj
 {
   robot_movement_interface::CommandList cmd_list;
 
+  // Process the first point
   if (joint_trajectory.points.size() >= 1)
     processFirstJtaPoint(joint_trajectory.points.front(), cmd_list);
   else
@@ -308,15 +309,9 @@ JtaCommandHandler::processJta(const trajectory_msgs::JointTrajectory& joint_traj
                   [&](const trajectory_msgs::JointTrajectoryPoint& pt) { processJtaPoint(pt, cmd_list); });
   }
 
-  // cmd_list.commands.emplace_back(processFirstJtaPoint(*joint_trajectory.points.begin()));
-
-  //  std::transform(joint_trajectory.points.begin() + 1, joint_trajectory.points.end() - 1,
-  //                 std::back_inserter(cmd_list.commands),
-  //                 [&](const trajectory_msgs::JointTrajectoryPoint& pt) { return processJtaPoint(pt); });
-
+  // Process the final point
   if (joint_trajectory.points.size() >= 2)
     processLastJtaPoint(joint_trajectory.points.back(), cmd_list);
-  // cmd_list.commands.emplace_back(processLastJtaPoint(joint_trajectory.points.back()));
 
   return cmd_list;
 }

--- a/rmi_driver/src/commands.cpp
+++ b/rmi_driver/src/commands.cpp
@@ -300,8 +300,13 @@ JtaCommandHandler::processJta(const trajectory_msgs::JointTrajectory& joint_traj
   else
     return cmd_list;
 
-  std::for_each(joint_trajectory.points.begin() + 1, joint_trajectory.points.end() - 1,
-                [&](const trajectory_msgs::JointTrajectoryPoint& pt) { processJtaPoint(pt, cmd_list); });
+  // Need to have at least 3 points to have something other that a first/last.
+  if (joint_trajectory.points.size() >= 3)
+  {
+    // Process all the points except the first/last normally
+    std::for_each(joint_trajectory.points.begin() + 1, joint_trajectory.points.end() - 1,
+                  [&](const trajectory_msgs::JointTrajectoryPoint& pt) { processJtaPoint(pt, cmd_list); });
+  }
 
   // cmd_list.commands.emplace_back(processFirstJtaPoint(*joint_trajectory.points.begin()));
 

--- a/rmi_driver/src/connector.cpp
+++ b/rmi_driver/src/connector.cpp
@@ -52,6 +52,7 @@ Connector::Connector(std::string ns, boost::asio::io_service &io_service, std::s
   , nh_(ns)
   , cmh_loader_(cmh_loader)
   , clear_commands_on_error_(clear_commands_on_error)
+  , logger_("CONNECTOR", ns)
 
 {
   joint_names_ = joint_names;
@@ -60,6 +61,8 @@ Connector::Connector(std::string ns, boost::asio::io_service &io_service, std::s
   command_list_sub_ = nh_.subscribe("command_list", 1, &Connector::subCB_CommandList, this);
 
   tool_frame_pub_ = nh_.advertise<robot_movement_interface::EulerFrame>("tool_frame", 30);
+
+  logger_.INFO() << "Created a new Connector";
 }
 
 bool Connector::connect()
@@ -106,7 +109,8 @@ void Connector::cancelSocketCmd(int timeout)
   if (socket_cmd_mutex_.try_lock_for(std::chrono::milliseconds(timeout)))
   {
     socket_cmd_mutex_.unlock();
-    ROS_INFO_STREAM("cancelSocketCmd() lock successful, no need to cancel");
+
+    logger_.INFO() << "cancelSocketCmd() lock successful, no need to cancel";
   }
   else  // It failed to respond.
   {
@@ -115,7 +119,7 @@ void Connector::cancelSocketCmd(int timeout)
     flush_socket_cmd_ = true;
     cmdSocketFlusher();  // Launch the flusher to consume any messages that are sent late.
 
-    ROS_INFO_STREAM("cancelSocketCmd() lock failed, canceling");
+    logger_.INFO() << "cancelSocketCmd() lock failed, canceling";
   }
 }
 
@@ -158,7 +162,8 @@ bool Connector::connectSocket(std::string host, int port, RobotCommand::CommandT
 
         if (ec)  // If it failed, try again
         {
-          ROS_INFO_STREAM(ns_ << " Socket(" << con_type << ") Ec was set " << ec.message());
+          logger_.INFO() << "Socket(" << con_type << ") Ec was set " << ec.message();
+
           std::this_thread::sleep_for(std::chrono::seconds(1));
           connectSocket(host, local_port, cmd_type);
         }
@@ -173,7 +178,7 @@ bool Connector::connectSocket(std::string host, int port, RobotCommand::CommandT
             get_thread_ = std::thread(&Connector::getThread, this);
           }
 
-          ROS_INFO_STREAM(ns_ << " Async Socket(" << con_type << ") established to " << host << ":" << local_port);
+          logger_.INFO() << " Async Socket(" << con_type << ") established to " << host << ":" << local_port;
         }
 
       });
@@ -218,7 +223,7 @@ void Connector::cmdSocketFlusher()
 
           if (e)  // If there is an error code, this was either cancelled or disconnected.
           {
-            ROS_INFO_STREAM(ns_ << " Connector::cmdSocketFlusher() is exiting with ec: " << e.message());
+            logger_.INFO() << "Connector::cmdSocketFlusher() is exiting with ec: " << e.message();
             flush_socket_cmd_ = false;
             return;
           }
@@ -228,7 +233,7 @@ void Connector::cmdSocketFlusher()
             std::istream is(&socket_cmd_flush_buff_);
             std::getline(is, line);
 
-            ROS_INFO_STREAM(ns_ << " Connector::cmdSocketFlusher() flushed a message (" << size << "): " << line);
+            logger_.INFO() << "Connector::cmdSocketFlusher() flushed a message (" << size << "): " << line;
             if (flush_socket_cmd_)
               cmdSocketFlusher();
           }
@@ -352,14 +357,14 @@ void Connector::addCommand(RobotCommandPtr command)
   }
   else
   {
-    ROS_ERROR_STREAM(ns_ << " Connector::addCommand invalid command type");
+    logger_.ERROR() << "Connector::addCommand invalid command type";
   }
 }
 
 void Connector::clearCommands()
 {
   command_list_mutex_.lock();
-  ROS_INFO_STREAM(ns_ << " Connector::clearCommands clearing " << command_list_.size() << " entries");
+  logger_.INFO() << "Connector::clearCommands clearing " << command_list_.size() << " entries";
   command_list_ = std::queue<RobotCommandPtr>();
   command_list_mutex_.unlock();
 }
@@ -369,7 +374,7 @@ bool Connector::commandListCb(const robot_movement_interface::CommandList &msg)
   auto conn = this;
   auto cmd_register = this->getCommandRegister();
 
-  ROS_INFO_STREAM(ns_ << " Received a new command_list of size: " << msg.commands.size());
+  logger_.INFO() << "Received a new command_list of size: " << msg.commands.size();
 
   // Temporary vector to hold processed commands in.  This allows me to abort and not add any commands if 1 in the list
   // was bad.
@@ -385,13 +390,13 @@ bool Connector::commandListCb(const robot_movement_interface::CommandList &msg)
 
     if (handler)
     {
-      ROS_INFO_STREAM(ns_ << " Found cmd handler: " << handler->getName());
+      logger_.INFO() << "Found cmd handler: " << handler->getName();
 
       // Create a new CommandPtr with the found handler
       auto robot_command_ptr = handler->processMsg(msg_cmd);
       if (!robot_command_ptr)
       {
-        ROS_ERROR_STREAM(ns_ << " Connector::commandListCb got a null telnet_command_ptr");
+        logger_.ERROR() << "Connector::commandListCb got a null telnet_command_ptr";
         goto error_abort;
       }
 
@@ -405,7 +410,7 @@ bool Connector::commandListCb(const robot_movement_interface::CommandList &msg)
       }
       else  // A Get was received as part of a CommandList.
       {
-        ROS_INFO_STREAM(ns_ << " Got a high priority command via a message: " << robot_command_ptr->getCommand());
+        logger_.INFO() << "Got a high priority command via a message: " << robot_command_ptr->getCommand();
 
         // Call cancelSocketCmd with async.  It will block while it tries to acquire the mutex.
         auto fut = std::async(std::launch::async, &Connector::cancelSocketCmd, conn, 50);
@@ -421,14 +426,15 @@ bool Connector::commandListCb(const robot_movement_interface::CommandList &msg)
         }
         publishRmiResult(robot_command_ptr->getCommandId(), abort_res_code, send_response);
 
-        ROS_INFO_STREAM(ns_ << " High priority response: " << send_response);
+        logger_.INFO() << "High priority response: " << send_response;
+
         fut.wait();
       }
       continue;
     }
     else  // if (!handler)
     {
-      ROS_ERROR_STREAM(ns_ << " Failed to find cmd handler for: " << msg_cmd);
+      logger_.ERROR() << "Failed to find cmd handler for: " << msg_cmd;
 
       // Send a failure response
       publishRmiResult(msg_cmd.command_id, CommandResultCodes::FAILED_TO_FIND_HANDLER, "Failed to find cmd handler");
@@ -448,7 +454,7 @@ bool Connector::commandListCb(const robot_movement_interface::CommandList &msg)
   return true;
 
 error_abort:
-  ROS_ERROR_STREAM(ns_ << " Not adding any commands from this list and clearing any existing commands!");
+  logger_.ERROR() << " Not adding any commands from this list and clearing any existing commands!";
   command_vect.clear();
   this->clearCommands();
   return true;
@@ -480,7 +486,7 @@ RobotCommandPtr Connector::findGetCommandHandler(const std::string &command_type
   auto get_handler = cmd_register_->findHandler(rmi_cmd);
   if (!get_handler)
   {
-    ROS_ERROR_STREAM(ns_ << " Failed to get handler for " << command_type << " " << pose_type);
+    logger_.ERROR() << "Failed to get handler for " << command_type << " " << pose_type;
     return nullptr;
   }
 
@@ -488,7 +494,7 @@ RobotCommandPtr Connector::findGetCommandHandler(const std::string &command_type
   auto robot_cmd = get_handler->processMsg(rmi_cmd);
   if (!robot_cmd)
   {
-    ROS_ERROR_STREAM(ns_ << "Failed to get a RobotCommand for " << command_type << " " << pose_type);
+    logger_.ERROR() << "Failed to get a RobotCommand for " << command_type << " " << pose_type;
   }
   return robot_cmd;
 }
@@ -505,7 +511,7 @@ void Connector::getThread()
   if (!get_joint_position || !get_version || !get_tool_frame)
   {
     /// @todo make a nice link to a section of docs
-    ROS_ERROR_STREAM("One of the getThread handlers failed to be found.  Your plugin MUST implement these!");
+    logger_.FATAL() << "One of the getThread handlers failed to be found.  Your plugin MUST implement these!";
 
     return;
   }
@@ -519,19 +525,19 @@ void Connector::getThread()
     response = sendCommand(*get_version);
     if (response.compare(cmd_register_->getVersion()) != 0)
     {
-      ROS_ERROR_STREAM(ns_ << " WARNING!  The version returned by the robot does NOT match the version of the active "
-                           << "command register!  Things may not work!");
-      ROS_ERROR_STREAM(ns_ << " Command register version: " << cmd_register_->getVersion()
-                           << ", robot version: " << response);
+      logger_.ERROR() << "WARNING!  The version returned by the robot does NOT match the version of the active "
+                      << "command register!  Things may not work!";
+
+      logger_.ERROR() << "Command register version: " << cmd_register_->getVersion() << ", robot version: " << response;
     }
     else
     {
-      ROS_INFO_STREAM(ns_ << " Command register version matches the robot: " << response);
+      logger_.INFO() << " Command register version matches the robot: " << response;
     }
   }
   catch (const boost::system::system_error &ex)
   {
-    ROS_INFO_STREAM(ns_ << " Connector::getThread exception: " << ex.what());
+    logger_.INFO() << "Connector::getThread exception: " << ex.what();
 
     if (ex.code() != boost::asio::error::operation_aborted)
     {
@@ -565,8 +571,8 @@ void Connector::getThread()
       pos_real = util::stringToDoubleVec(response);
       if (pos_real.size() != 6)
       {
-        ROS_ERROR_STREAM(ns_ << " ERROR: Connector::getThread GET TOOL_FRAME size wrong!  Expected 6, got "
-                             << pos_real.size() << ".  Raw msg: " << response);
+        logger_.ERROR() << " ERROR: Connector::getThread GET TOOL_FRAME size wrong!  Expected 6, got "
+                        << pos_real.size() << ".  Raw msg: " << response;
         continue;
       }
 
@@ -579,12 +585,13 @@ void Connector::getThread()
     }
     catch (const boost::bad_lexical_cast &)
     {
-      ROS_ERROR_STREAM(ns_ << " Connector::getThread: Unable to parse Get response: " << response);
+      logger_.ERROR() << " Connector::getThread: Unable to parse Get response: " << response;
+
       continue;
     }
     catch (const boost::system::system_error &ex)
     {
-      ROS_INFO_STREAM(ns_ << " Connector::getThread exception: " << ex.what());
+      logger_.INFO() << " Connector::getThread exception: " << ex.what();
 
       if (ex.code() != boost::asio::error::operation_aborted)
       {
@@ -601,7 +608,7 @@ void Connector::getThread()
 void Connector::cmdThread()
 {
   ros::Rate rate(30);
-  ROS_INFO_STREAM(ns_ << " Connector::cmdThread() starting");
+  logger_.INFO() << " Connector::cmdThread() starting";
 
   RobotCommandPtr cmd;
 
@@ -630,7 +637,7 @@ void Connector::cmdThread()
       oss << *cmd;
 
       auto cmd_str = oss.str();
-      ROS_INFO_STREAM(ns_ << " Connector::cmdThread Cmd (" << cmd_str.length() << "): " << cmd_str);
+      logger_.INFO() << " Connector::cmdThread Cmd (" << cmd_str.length() << "): " << cmd_str;
     }
     command_list_mutex_.unlock();
 
@@ -644,21 +651,23 @@ void Connector::cmdThread()
         result.command_id = cmd->getCommandId();
         if (cmd->checkResponse(response))
         {
-          ROS_INFO_STREAM(ns_ << " Connector::cmdThread sendCommand OK. Response: " << response << std::endl);
+          logger_.INFO() << " Connector::cmdThread sendCommand OK. Response: " << response << "\n";
           result.result_code = 0;
         }
         else
         {
           /// OK only indicates that the command was received and processed successfully and execution should continue,
           /// not that the actual result was good/true/whatever.  A not-OK response is always a problem.
-          ROS_INFO_STREAM(ns_ << " Connector::cmdThread sendCommand NOT OK. Response: " << response << std::endl);
+          // ROS_INFO_STREAM(ns_ << " Connector::cmdThread sendCommand NOT OK. Response: " << response << std::endl);
+          logger_.INFO() << " Connector::cmdThread sendCommand NOT OK. Response: " << response << "\n";
+
           result.result_code = 1;
 
           ///@todo think about how this might affect the order of responses.
           // Clear the list if set.
           if (clear_commands_on_error_)
           {
-            ROS_INFO_STREAM(ns_ << " Connector::cmdThread is clearing any remaining commands after receiving an error");
+            logger_.INFO() << " Connector::cmdThread is clearing any remaining commands after receiving an error";
             clearCommands();
           }
         }
@@ -678,7 +687,7 @@ void Connector::cmdThread()
       }
       catch (const boost::system::system_error &ex)
       {
-        ROS_INFO_STREAM(ns_ << " Connector::cmdThread exception: " << ex.what());
+        logger_.INFO() << " Connector::cmdThread exception: " << ex.what();
 
         // If the error is cause by anything other than a cancel, reconnect
         if (ex.code() != boost::asio::error::operation_aborted)
@@ -690,7 +699,7 @@ void Connector::cmdThread()
 
           if (clear_commands_on_error_)
           {
-            ROS_INFO_STREAM(ns_ << " Connector::cmdThread is clearing any remaining commands due to the socket error");
+            logger_.INFO() << " Connector::cmdThread is clearing any remaining commands due to the socket error";
             clearCommands();
           }
 

--- a/rmi_driver/src/connector.cpp
+++ b/rmi_driver/src/connector.cpp
@@ -410,7 +410,7 @@ bool Connector::commandListCb(const robot_movement_interface::CommandList &msg)
       }
       else  // A Get was received as part of a CommandList.
       {
-        logger_.INFO() << "Got a high priority command via a message: " << robot_command_ptr->getCommand();
+        logger_.WARN() << "Got a high priority command via a message: " << robot_command_ptr->getCommand();
 
         // Call cancelSocketCmd with async.  It will block while it tries to acquire the mutex.
         auto fut = std::async(std::launch::async, &Connector::cancelSocketCmd, conn, 50);
@@ -501,6 +501,7 @@ RobotCommandPtr Connector::findGetCommandHandler(const std::string &command_type
 
 void Connector::getThread()
 {
+  util::setThreadName("get_thr");
   ros::Rate rate(50);
 
   // Fetch the required RobotCommands from the plugin.
@@ -607,6 +608,7 @@ void Connector::getThread()
 
 void Connector::cmdThread()
 {
+  util::setThreadName("cmd_thr");
   ros::Rate rate(30);
   logger_.INFO() << " Connector::cmdThread() starting";
 

--- a/rmi_driver/src/driver.cpp
+++ b/rmi_driver/src/driver.cpp
@@ -95,7 +95,7 @@ void Driver::addConnection(std::string ns, std::string host, int port, std::vect
                                             config_.clear_commands_on_error_);
   conn_map_.emplace(conn_num_, shared);
 
-  auto jta = std::make_shared<JointTrajectoryAction>(ns);
+  auto jta = std::make_shared<JointTrajectoryAction>(ns, joint_names);
   jta_map_.emplace(conn_num_, jta);
 
   auto &conn = conn_map_.at(conn_num_);

--- a/rmi_driver/src/driver.cpp
+++ b/rmi_driver/src/driver.cpp
@@ -95,7 +95,7 @@ void Driver::addConnection(std::string ns, std::string host, int port, std::vect
                                             config_.clear_commands_on_error_);
   conn_map_.emplace(conn_num_, shared);
 
-  auto jta = std::make_shared<JointTrajectoryAction>(ns, joint_names);
+  auto jta = std::make_shared<JointTrajectoryAction>(ns, joint_names, commands->getJtaCommandHandler());
   jta_map_.emplace(conn_num_, jta);
 
   auto &conn = conn_map_.at(conn_num_);

--- a/rmi_driver/src/driver.cpp
+++ b/rmi_driver/src/driver.cpp
@@ -101,8 +101,15 @@ void Driver::addConnection(std::string ns, std::string host, int port, std::vect
                                             config_.clear_commands_on_error_);
   conn_map_.emplace(conn_num_, shared);
 
-  auto jta = std::make_shared<JointTrajectoryAction>(ns, joint_names, commands->getJtaCommandHandler());
-  jta_map_.emplace(conn_num_, jta);
+  if (config_.use_rmi_driver_jta_)
+  {
+    auto jta = std::make_shared<JointTrajectoryAction>(ns, joint_names, commands->getJtaCommandHandler());
+    jta_map_.emplace(conn_num_, jta);
+  }
+  else
+  {
+    logger_.WARN() << "use_rmi_driver_jta disabled. " << ns << "/joint_trajectory_action will not be launched.";
+  }
 
   auto &conn = conn_map_.at(conn_num_);
   conn->connect();

--- a/rmi_driver/src/driver.cpp
+++ b/rmi_driver/src/driver.cpp
@@ -30,13 +30,18 @@
 #include "rmi_driver/driver.h"
 #include <future>
 #include <iostream>
+#include "rmi_driver/util.h"
 
 namespace rmi_driver
 {
-Driver::Driver() : work_(io_service_)
+Driver::Driver() : work_(io_service_), logger_("DRIVER", "/")
 {
   // boost::asio::io_service work(io_service_);
   io_service_thread_ = std::thread([&]() { io_service_.run(); });
+
+  util::setThreadName(io_service_thread_, "io_svc_thr");
+
+  util::setThreadName("driver_thr");
 
   ros::NodeHandle nh;
   config_.loadConfig(nh);
@@ -44,10 +49,10 @@ Driver::Driver() : work_(io_service_)
 
 void Driver::start()
 {
-  ROS_INFO_STREAM("There are " << config_.connections_.size() << " connections");
+  logger_.INFO() << "There are " << config_.connections_.size() << " connections";
   for (auto &&con_cfg : config_.connections_)
   {
-    ROS_INFO_STREAM("Loading plugin: " << con_cfg.rmi_plugin_package_);
+    logger_.INFO() << "Loading plugin: " << con_cfg.rmi_plugin_package_;
     try
     {
       // Will be stored in the Connector.  Making it here to keep Plugin loading stuff out of Connector.
@@ -57,13 +62,13 @@ void Driver::start()
       // cmh_loader->createInstance() returns a boost::shared_ptr but I want a std one.
       CommandRegisterPtr cmd_register = cmh_loader->createUniqueInstance(con_cfg.rmi_plugin_lookup_name_);
       cmd_register->initialize(con_cfg.joints_);
-      ROS_INFO_STREAM("Loaded the plugin successfully");
+      logger_.INFO() << "Loaded the plugin successfully";
 
       // Display some info about the loaded plugin
-      ROS_INFO_STREAM("There are " << cmd_register->handlers().size() << " handlers registered");
+      logger_.INFO() << "There are " << cmd_register->handlers().size() << " handlers registered";
       for (auto &cmh : cmd_register->handlers())
       {
-        ROS_INFO_STREAM(*cmh);
+        logger_.INFO() << *cmh;
       }
 
       // Add the connection from the current config
@@ -71,7 +76,7 @@ void Driver::start()
     }
     catch (pluginlib::PluginlibException &ex)
     {
-      ROS_ERROR("The plugin failed to load for some reason. Error: %s", ex.what());
+      logger_.ERROR() << "The plugin failed to load for some reason. Error: %s", ex.what();
     }
   }
 
@@ -81,6 +86,7 @@ void Driver::start()
 
   // Publish joint states.  Will aggregate multiple robots.
   pub_thread_ = std::thread(&Driver::publishJointState, this);
+  util::setThreadName(pub_thread_, "pub_jt_state");
 
   return;
 }
@@ -106,8 +112,7 @@ void Driver::publishJointState()
 {
   ros::Rate pub_rate(config_.publishing_rate_);
 
-  ROS_INFO_STREAM(__func__ << "Driver pub starting");
-  // ROS_INFO_NAMED("Driver", "publishJointState");
+  logger_.INFO() << "Driver pub starting";
 
   sensor_msgs::JointState stateFull;
   while (ros::ok())

--- a/rmi_driver/src/driver.cpp
+++ b/rmi_driver/src/driver.cpp
@@ -95,6 +95,9 @@ void Driver::addConnection(std::string ns, std::string host, int port, std::vect
                                             config_.clear_commands_on_error_);
   conn_map_.emplace(conn_num_, shared);
 
+  auto jta = std::make_shared<JointTrajectoryAction>(ns);
+  jta_map_.emplace(conn_num_, jta);
+
   auto &conn = conn_map_.at(conn_num_);
   conn->connect();
 }

--- a/rmi_driver/src/joint_trajectory_action.cpp
+++ b/rmi_driver/src/joint_trajectory_action.cpp
@@ -140,10 +140,17 @@ void JointTrajectoryAction::subCB_CommandResult(const robot_movement_interface::
 {
   //  if ( active_goal_.isValid() && msg->command_id == cmd_id_ &&
   //      active_goal_.getGoalStatus().status == actionlib_msgs::GoalStatus::ACTIVE)
-  if (has_goal_ && msg->command_id == cmd_id_)
+  if (has_goal_)
   {
-    active_goal_.setSucceeded();
-    has_goal_ = false;
+    if (msg->result_code != 0)  // If any message is an error, just stop
+    {
+      abortGoal(-100, "subCB_CommandResult received a msg with non-zero result code");
+    }
+    else if (msg->command_id == cmd_id_)
+    {
+      active_goal_.setSucceeded();
+      has_goal_ = false;
+    }
   }
 }
 

--- a/rmi_driver/src/joint_trajectory_action.cpp
+++ b/rmi_driver/src/joint_trajectory_action.cpp
@@ -40,6 +40,7 @@ JointTrajectoryAction::JointTrajectoryAction(std::string ns, const std::vector<s
                    boost::bind(&JointTrajectoryAction::cancelCB, this, _1), false)
   , conf_joint_names_(joint_names)
   , ns_(ns)
+  , nh_(ns)
   , jta_handler_(jta_handler)
   , has_goal_(false)
   , logger_("JTA", ns)

--- a/rmi_driver/src/joint_trajectory_action.cpp
+++ b/rmi_driver/src/joint_trajectory_action.cpp
@@ -34,8 +34,9 @@ namespace rmi_driver
 {
 }  // namespace rmi_driver
 
-rmi_driver::JointTrajectoryAction::JointTrajectoryAction(std::string ns)
+rmi_driver::JointTrajectoryAction::JointTrajectoryAction(std::string ns, const std::vector<std::string> &joint_names)
   : action_server_(nh_, ns + "/joint_trajectory_action", boost::bind(&JointTrajectoryAction::goalCB, this, _1), false)
+  , conf_joint_names_(joint_names)
 {
   pub_rmi_ = nh_.advertise<robot_movement_interface::CommandList>(ns + "/command_list", 1);
 
@@ -46,15 +47,16 @@ rmi_driver::JointTrajectoryAction::JointTrajectoryAction(std::string ns)
 
 void rmi_driver::JointTrajectoryAction::test(JointTractoryActionServer::GoalHandle &gh)
 {
-  std::vector<std::string> conf_names = { "shoulder_pan_joint", "shoulder_lift_joint", "elbow_joint", "wrist_1_joint",
-                                          "wrist_2_joint",      "wrist_3_joint",       "rail_to_base" };
+  //  std::vector<std::string> conf_names = { "shoulder_pan_joint", "shoulder_lift_joint", "elbow_joint",
+  //  "wrist_1_joint",
+  //                                          "wrist_2_joint",      "wrist_3_joint",       "rail_to_base" };
 
   auto &traj = gh.getGoal()->trajectory;
 
   auto &joint_names = traj.joint_names;
   std::vector<int> mapping;
 
-  for (auto &&name : conf_names)
+  for (auto &&name : conf_joint_names_)
   {
     auto idx = std::find(joint_names.begin(), joint_names.end(), name) - joint_names.begin();
     mapping.push_back(idx);

--- a/rmi_driver/src/joint_trajectory_action.cpp
+++ b/rmi_driver/src/joint_trajectory_action.cpp
@@ -84,6 +84,20 @@ void rmi_driver::JointTrajectoryAction::test(JointTractoryActionServer::GoalHand
     std::transform(mapping.begin(), mapping.end(), std::back_inserter(cmd.pose),
                    [&](int i) { return point.positions[i]; });
 
+    if (point.velocities.size() == mapping.size())
+    {
+      cmd.velocity_type = "ROS";
+      std::transform(mapping.begin(), mapping.end(), std::back_inserter(cmd.velocity),
+                     [&](int i) { return point.velocities[i]; });
+    }
+
+    if (point.accelerations.size() == mapping.size())
+    {
+      cmd.acceleration_type = "ROS";
+      std::transform(mapping.begin(), mapping.end(), std::back_inserter(cmd.acceleration),
+                     [&](int i) { return point.accelerations[i]; });
+    }
+
     cmd_list.commands.push_back(std::move(cmd));
   }
 

--- a/rmi_driver/src/joint_trajectory_action.cpp
+++ b/rmi_driver/src/joint_trajectory_action.cpp
@@ -64,11 +64,20 @@ void JointTrajectoryAction::newGoal(JointTractoryActionServer::GoalHandle &gh)
   auto &joint_names = traj.joint_names;
 
   std::vector<size_t> mapping;  // mapping[0] will contain the position of joint0 in the vectors
+  if (joint_names.size() != conf_joint_names_.size())
+  {
+    reject(control_msgs::FollowJointTrajectoryResult::INVALID_JOINTS, "joint_names.size() != conf_joint_names_.size()");
+    return;
+  }
+
+  // mapping[0] will contain the position of joint0 in the vectors.  This way I only have to search once.
+  std::vector<size_t> mapping;
 
   for (auto &&name : conf_joint_names_)
   {
     auto idx = std::find(joint_names.begin(), joint_names.end(), name) - joint_names.begin();
-    mapping.push_back(idx);
+    if (idx < joint_names.size())
+      mapping.push_back(idx);
   }
   if (mapping.size() != joint_names.size())
   {

--- a/rmi_driver/src/joint_trajectory_action.cpp
+++ b/rmi_driver/src/joint_trajectory_action.cpp
@@ -34,10 +34,10 @@ namespace rmi_driver
 {
 }  // namespace rmi_driver
 
-rmi_driver::JointTrajectoryAction::JointTrajectoryAction()
-  : action_server_(nh_, "ur_joint_trajectory_action", boost::bind(&JointTrajectoryAction::goalCB, this, _1), false)
+rmi_driver::JointTrajectoryAction::JointTrajectoryAction(std::string ns)
+  : action_server_(nh_, ns + "/joint_trajectory_action", boost::bind(&JointTrajectoryAction::goalCB, this, _1), false)
 {
-  pub_rmi_ = nh_.advertise<robot_movement_interface::CommandList>("command_list", 1);
+  pub_rmi_ = nh_.advertise<robot_movement_interface::CommandList>(ns + "/command_list", 1);
 
   sub_rmi_ = nh_.subscribe("command_result", 1, &JointTrajectoryAction::subCB_CommandResult, this);
 
@@ -49,20 +49,10 @@ void rmi_driver::JointTrajectoryAction::test(JointTractoryActionServer::GoalHand
   std::vector<std::string> conf_names = { "shoulder_pan_joint", "shoulder_lift_joint", "elbow_joint", "wrist_1_joint",
                                           "wrist_2_joint",      "wrist_3_joint",       "rail_to_base" };
 
-  //  goal.goal.trajectory.joint_names = { "elbow_joint",   "rail_to_base",  "shoulder_lift_joint",
-  //  "shoulder_pan_joint",
-  //                                       "wrist_1_joint", "wrist_2_joint", "wrist_3_joint" };
-
   auto &traj = gh.getGoal()->trajectory;
 
   auto &joint_names = traj.joint_names;
   std::vector<int> mapping;
-
-  //  for (auto &&name : joint_names)
-  //  {
-  //    auto idx = std::find(conf_names.begin(), conf_names.end(), name) - conf_names.begin();
-  //    mapping.push_back(idx);
-  //  }
 
   for (auto &&name : conf_names)
   {

--- a/rmi_driver/src/joint_trajectory_action.cpp
+++ b/rmi_driver/src/joint_trajectory_action.cpp
@@ -30,12 +30,6 @@
 #include "rmi_driver/joint_trajectory_action.h"
 #include "rmi_driver/util.h"
 
-#include <boost/algorithm/cxx11/is_permutation.hpp>
-#include <boost/range/algorithm.hpp>
-//#include <boost/range/algorithm/transform.hpp>
-#include <boost/iterator/permutation_iterator.hpp>
-#include <boost/iterator/zip_iterator.hpp>
-
 #include <vector>
 
 namespace rmi_driver
@@ -50,7 +44,7 @@ JointTrajectoryAction::JointTrajectoryAction(std::string ns, const std::vector<s
 {
   pub_rmi_ = nh_.advertise<robot_movement_interface::CommandList>(ns + "/command_list", 1);
 
-  sub_rmi_ = nh_.subscribe("command_result", 1, &JointTrajectoryAction::subCB_CommandResult, this);
+  sub_rmi_ = nh_.subscribe(ns + "/command_result", 1, &JointTrajectoryAction::subCB_CommandResult, this);
 
   action_server_.start();
 }

--- a/rmi_driver/src/joint_trajectory_action.cpp
+++ b/rmi_driver/src/joint_trajectory_action.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2017, Doug Smith
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ *  Created on: Nov 29, 2017
+ *      Author: Doug Smith
+ */
+
+#include <rmi_driver/joint_trajectory_action.h>
+#include <vector>
+
+namespace rmi_driver
+{
+}  // namespace rmi_driver
+
+rmi_driver::JointTrajectoryAction::JointTrajectoryAction()
+  : action_server_(nh_, "ur_joint_trajectory_action", boost::bind(&JointTrajectoryAction::goalCB, this, _1), false)
+{
+  pub_rmi_ = nh_.advertise<robot_movement_interface::CommandList>("command_list", 1);
+
+  sub_rmi_ = nh_.subscribe("command_result", 1, &JointTrajectoryAction::subCB_CommandResult, this);
+
+  action_server_.start();
+}
+
+void rmi_driver::JointTrajectoryAction::test(JointTractoryActionServer::GoalHandle &gh)
+{
+  std::vector<std::string> conf_names = { "shoulder_pan_joint", "shoulder_lift_joint", "elbow_joint", "wrist_1_joint",
+                                          "wrist_2_joint",      "wrist_3_joint",       "rail_to_base" };
+
+  //  goal.goal.trajectory.joint_names = { "elbow_joint",   "rail_to_base",  "shoulder_lift_joint",
+  //  "shoulder_pan_joint",
+  //                                       "wrist_1_joint", "wrist_2_joint", "wrist_3_joint" };
+
+  auto &traj = gh.getGoal()->trajectory;
+
+  auto &joint_names = traj.joint_names;
+  std::vector<int> mapping;
+
+  //  for (auto &&name : joint_names)
+  //  {
+  //    auto idx = std::find(conf_names.begin(), conf_names.end(), name) - conf_names.begin();
+  //    mapping.push_back(idx);
+  //  }
+
+  for (auto &&name : conf_names)
+  {
+    auto idx = std::find(joint_names.begin(), joint_names.end(), name) - joint_names.begin();
+    mapping.push_back(idx);
+  }
+
+  for (auto &&idx : mapping)
+  {
+    ROS_INFO_STREAM(idx);
+  }
+
+  // trajectory_msgs::JointTrajectoryPoint pt;
+  // pt.positions = { 2, 6, 1, 0, 3, 4, 5 };
+  // goal.goal.trajectory.points.push_back(pt);
+
+  robot_movement_interface::CommandList cmd_list;
+
+  cmd_id_ = 0;
+  for (auto &&point : traj.points)
+  {
+    robot_movement_interface::Command cmd;
+    cmd.command_id = cmd_id_++;
+
+    cmd.command_type = "PTP";
+    cmd.pose_type = "JOINTS";
+    std::transform(mapping.begin(), mapping.end(), std::back_inserter(cmd.pose),
+                   [&](int i) { return point.positions[i]; });
+
+    cmd_list.commands.push_back(std::move(cmd));
+  }
+
+  robot_movement_interface::Command cmd;
+  cmd.command_id = cmd_id_;
+  cmd.command_type = "WAIT";
+  cmd.pose_type = "IS_FINISHED";
+  cmd_list.commands.push_back(cmd);
+
+  // std::transform(mapping.begin(), mapping.end(), sorted.begin(), [&](int i) { return pt.positions[i]; });
+
+  // std::transform(mapping.begin(), mapping.end(), std::back_inserter(cmd.pose), [&](int i) { return pt.positions[i];
+  // });
+
+  // ROS_INFO_STREAM(cmd_list);
+
+  pub_rmi_.publish(cmd_list);
+  JointTractoryActionServer::Result res;
+}
+
+void rmi_driver::JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle gh)
+{
+  active_goal_ = gh;
+  gh.setAccepted();
+  test(gh);
+}
+
+void rmi_driver::JointTrajectoryAction::subCB_CommandResult(const robot_movement_interface::ResultConstPtr &msg)
+{
+  if (msg->command_id == cmd_id_)
+    active_goal_.setSucceeded();
+}

--- a/rmi_driver/src/main.cpp
+++ b/rmi_driver/src/main.cpp
@@ -1,5 +1,6 @@
 #include <ros/ros.h>
 #include "rmi_driver/driver.h"
+#include "rmi_driver/joint_trajectory_action.h"
 
 using namespace rmi_driver;
 int main(int argc, char **argv)
@@ -11,6 +12,9 @@ int main(int argc, char **argv)
   rmi_driver::Driver driver;
 
   driver.start();
+
+  JointTrajectoryAction jta;
+  // jta.test();
 
   ros::spin();
 

--- a/rmi_driver/src/main.cpp
+++ b/rmi_driver/src/main.cpp
@@ -13,9 +13,6 @@ int main(int argc, char **argv)
 
   driver.start();
 
-  JointTrajectoryAction jta;
-  // jta.test();
-
   ros::spin();
 
   return 0;

--- a/rmi_driver/src/main.cpp
+++ b/rmi_driver/src/main.cpp
@@ -5,9 +5,11 @@
 using namespace rmi_driver;
 int main(int argc, char **argv)
 {
-  ros::init(argc, argv, "keba_driver");
+  ros::init(argc, argv, "rmi_driver");
 
   ros::NodeHandle nh;
+
+  ros::Duration(1).sleep();  // Sleep to allow rqt_console to detect the new node
 
   rmi_driver::Driver driver;
 

--- a/rmi_driver/src/main.cpp
+++ b/rmi_driver/src/main.cpp
@@ -9,6 +9,7 @@ int main(int argc, char **argv)
 
   ros::NodeHandle nh;
 
+  ROS_INFO_STREAM("rmi_driver starting after 1 second delay");
   ros::Duration(1).sleep();  // Sleep to allow rqt_console to detect the new node
 
   rmi_driver::Driver driver;

--- a/rmi_driver/src/rmi_config.cpp
+++ b/rmi_driver/src/rmi_config.cpp
@@ -41,6 +41,8 @@ bool DriverConfig::loadConfig(ros::NodeHandle& nh)
 
   loadParam(nh, "/rmi_driver/clear_commands_on_error", clear_commands_on_error_, true);
 
+  loadParam(nh, "/rmi_driver/use_rmi_driver_jta", use_rmi_driver_jta_, true);
+
   // Load the connections
   std::string config_name = "rmi_driver_map";
   return getListParam(config_name, connections_);

--- a/rmi_driver/src/rmi_logger.cpp
+++ b/rmi_driver/src/rmi_logger.cpp
@@ -28,3 +28,58 @@
  */
 
 #include "rmi_driver/rmi_logger.h"
+
+namespace rmi_driver
+{
+namespace rmi_log
+{
+RmiLogger::RmiLogger(const std::string& module_name, const std::string& ns) : module_name_(module_name), ns_(ns)
+{
+}
+
+void RmiLogger::setLoggerLevel(Level level)
+{
+  std::string log_name = std::string(ROSCONSOLE_NAME_PREFIX) + "." + module_name_;
+  if (ros::console::set_logger_level(log_name, level))
+    ros::console::notifyLoggerLevelsChanged();
+}
+
+RmiLogger::DebugEx::DebugEx(const std::string& module, const std::string& ns, Level level)
+  : module_name_(module), ns_(ns), level_(level)
+{
+}
+
+RmiLogger::DebugEx::DebugEx(const DebugEx& other)
+  : module_name_(other.module_name_), ns_(other.ns_), level_(other.level_)
+{
+}
+
+RmiLogger::DebugEx::~DebugEx()
+{
+  std::string str = ss_.str();
+  if (!str.empty())
+  {
+    switch (level_)
+    {
+      case Level::Debug:
+        ROS_DEBUG_STREAM_NAMED(module_name_, module_name_ << ":" << ns_ << " " << str);
+        break;
+      case Level::Info:
+        ROS_INFO_STREAM_NAMED(module_name_, module_name_ << ":" << ns_ << " " << str);
+        break;
+      case Level::Warn:
+        ROS_WARN_STREAM_NAMED(module_name_, module_name_ << ":" << ns_ << " " << str);
+        break;
+      case Level::Error:
+        ROS_ERROR_STREAM_NAMED(module_name_, module_name_ << ":" << ns_ << " " << str);
+        break;
+      case Level::Fatal:
+        ROS_FATAL_STREAM_NAMED(module_name_, module_name_ << ":" << ns_ << " " << str);
+        break;
+    }
+  }
+}
+
+}  // namespace log
+
+}  // namespace rmi_driver

--- a/rmi_driver/src/rmi_logger.cpp
+++ b/rmi_driver/src/rmi_logger.cpp
@@ -54,27 +54,39 @@ RmiLogger::DebugEx::DebugEx(const DebugEx& other)
 {
 }
 
+RmiLogger::DebugEx::DebugEx(DebugEx&& other)
+  : module_name_(std::move(other.module_name_)), ns_(std::move(other.ns_)), level_(other.level_)
+{
+}
+
 RmiLogger::DebugEx::~DebugEx()
 {
   std::string str = ss_.str();
   if (!str.empty())
   {
+    //    auto log_name = getName();
+    //    if (throttle_ > 0)
+    //    {
+    //      ROS_ERROR_STREAM_THROTTLE_NAMED(throttle_, log_name, log_name << " " << str);
+    //      return;
+    //    }
+
     switch (level_)
     {
       case Level::Debug:
-        ROS_DEBUG_STREAM_NAMED(module_name_, module_name_ << ":" << ns_ << " " << str);
+        ROS_DEBUG_STREAM_NAMED(getName(), module_name_ << ":" << ns_ << " " << str);
         break;
       case Level::Info:
-        ROS_INFO_STREAM_NAMED(module_name_, module_name_ << ":" << ns_ << " " << str);
+        ROS_INFO_STREAM_NAMED(getName(), module_name_ << ":" << ns_ << " " << str);
         break;
       case Level::Warn:
-        ROS_WARN_STREAM_NAMED(module_name_, module_name_ << ":" << ns_ << " " << str);
+        ROS_WARN_STREAM_NAMED(getName(), module_name_ << ":" << ns_ << " " << str);
         break;
       case Level::Error:
-        ROS_ERROR_STREAM_NAMED(module_name_, module_name_ << ":" << ns_ << " " << str);
+        ROS_ERROR_STREAM_NAMED(getName(), module_name_ << ":" << ns_ << " " << str);
         break;
       case Level::Fatal:
-        ROS_FATAL_STREAM_NAMED(module_name_, module_name_ << ":" << ns_ << " " << str);
+        ROS_FATAL_STREAM_NAMED(getName(), module_name_ << ":" << ns_ << " " << str);
         break;
     }
   }

--- a/rmi_driver/src/rmi_logger.cpp
+++ b/rmi_driver/src/rmi_logger.cpp
@@ -54,25 +54,48 @@ void RmiLogger::setLoggerLevel(Level level)
 
 RmiLogger::DebugEx::DebugEx(const std::string& module, const std::string& ns, ros::console::LogLocation& loc,
                             Level level)
-  : module_name_(module), ns_(ns), level_(level), loc_(loc)
+  : module_name_(module)
+  , ns_(ns)
+  , level_(level)
+  , loc_(loc)
+  , file_(__FILE__)
+  , line_(__LINE__)
+  , function_(__ROSCONSOLE_FUNCTION__)
+{
+}
+
+RmiLogger::DebugEx::DebugEx(const std::string& module, const std::string& ns, ros::console::LogLocation& loc,
+                            Level level, const char* file, int line, const char* function)
+  : module_name_(module), ns_(ns), level_(level), loc_(loc), file_(file), line_(line), function_(function)
 {
 }
 
 RmiLogger::DebugEx::DebugEx(const DebugEx& other)
-  : module_name_(other.module_name_), ns_(other.ns_), level_(other.level_), loc_(other.loc_)
+  : module_name_(other.module_name_)
+  , ns_(other.ns_)
+  , level_(other.level_)
+  , loc_(other.loc_)
+  , file_(other.file_)
+  , line_(other.line_)
+  , function_(other.function_)
 {
 }
 
 RmiLogger::DebugEx::DebugEx(DebugEx&& other)
-  : module_name_(std::move(other.module_name_)), ns_(std::move(other.ns_)), level_(other.level_), loc_(other.loc_)
+  : module_name_(std::move(other.module_name_))
+  , ns_(std::move(other.ns_))
+  , level_(other.level_)
+  , loc_(other.loc_)
+  , file_(other.file_)
+  , line_(other.line_)
+  , function_(other.function_)
 {
 }
 
 RmiLogger::DebugEx::~DebugEx()
 {
   std::string str = ss_.str();
-  std::stringstream lss;
-  lss << module_name_ << ":" << ns_ << " " << str;
+
   if (!str.empty())
   {
     //    auto log_name = getName();
@@ -82,6 +105,9 @@ RmiLogger::DebugEx::~DebugEx()
     //      return;
     //    }
 
+    std::stringstream lss;
+    lss << module_name_ << ":" << ns_ << " " << str;
+
     ros::console::setLogLocationLevel(&loc_, level_);
     ros::console::checkLogLocationEnabled(&loc_);
 
@@ -89,28 +115,8 @@ RmiLogger::DebugEx::~DebugEx()
     if (!cont)
       return;
 
-    std::string logger_name = getName();
-
-    switch (level_)
-    {
-      case Level::Debug:
-        ROS_DEBUG_STREAM_NAMED(getName(), module_name_ << ":" << ns_ << " " << str);
-        break;
-      case Level::Info:
-
-        ros::console::print(0, loc_.logger_, loc_.level_, lss, __FILE__, __LINE__, __ROSCONSOLE_FUNCTION__);
-        // ROS_INFO_STREAM_NAMED(logger_name, module_name_ << ":" << ns_ << " " << str);
-        break;
-      case Level::Warn:
-        ROS_WARN_STREAM_NAMED(getName(), module_name_ << ":" << ns_ << " " << str);
-        break;
-      case Level::Error:
-        ROS_ERROR_STREAM_NAMED(getName(), module_name_ << ":" << ns_ << " " << str);
-        break;
-      case Level::Fatal:
-        ROS_FATAL_STREAM_NAMED(getName(), module_name_ << ":" << ns_ << " " << str);
-        break;
-    }
+    ros::console::print(0, loc_.logger_, loc_.level_, lss, file_, line_, function_);
+    return;
   }
 }
 

--- a/rmi_driver/src/rmi_logger.cpp
+++ b/rmi_driver/src/rmi_logger.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2017, Doug Smith
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ *  Created on: Dec 13, 2017
+ *      Author: Doug Smith
+ */
+
+#include "rmi_driver/rmi_logger.h"

--- a/rmi_driver/src/util.cpp
+++ b/rmi_driver/src/util.cpp
@@ -32,6 +32,8 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/tokenizer.hpp>
 
+#include <boost/spirit/include/qi.hpp>
+
 namespace rmi_driver
 {
 namespace util
@@ -50,17 +52,74 @@ std::string floatToStringNoTrailing(float fval, int precision)
   return str;
 }
 
+using boost::spirit::qi::double_;
+using boost::spirit::qi::parse;
+
+namespace qi = boost::spirit::qi;
+
 std::vector<double> stringToDoubleVec(const std::string& s)
 {
   std::vector<double> doubleVec;
-  std::vector<std::string> strVec;
 
-  // Split the string at spaces into a vector of strings
-  boost::split(strVec, s, boost::is_any_of(" "), boost::token_compress_on);
+  // So, boost::split is the least efficient thing ever.  Use qi instead.
 
-  // Insert the double value of each entry
-  std::transform(strVec.begin(), strVec.end(), std::back_inserter(doubleVec),
-                 [](const std::string& val) { return boost::lexical_cast<double>(val); });
+  // std::vector<std::string> strVec;
+
+  //
+  //  // Split the string at spaces into a vector of strings
+  //  // boost::split(strVec, s, boost::is_any_of(" "), boost::token_compress_on);
+  //  boost::split(strVec, s, boost::is_space(), boost::token_compress_on);
+  //  t.stop();
+  //
+  //  auto time_total = t.getTime();
+  //  std::cout << "duration boost::split " << t.getTime() << " ";
+  //
+  //  t.reset();
+  //  t.start();
+  //  // Insert the double value of each entry
+  //
+  //  doubleVec.reserve(10);
+  //  std::transform(strVec.begin(), strVec.end(), std::back_inserter(doubleVec),
+  //                 [](const std::string& val) { return boost::lexical_cast<double>(val); });
+  //  t.stop();
+  //
+  //  time_total += t.getTime();
+  //  std::cout << "duration transform: " << t.getTime() << " total: " << time_total << " (" << s << ")" << std::endl;
+  //
+  //  // Clock::time_point t0 = Clock::now();
+  //
+  //  {
+  //    std::vector<double> doubleVec;
+  //    t.reset();
+  //    t.start();
+  //    auto s_trim = boost::trim_copy(s);
+  //    doubleVec.reserve(10);
+  //    std::stringstream ss(s_trim);
+  //
+  //    double d;
+  //    while (ss >> d)
+  //      doubleVec.push_back(d);
+  //
+  //    t.stop();
+  //    std::cout << "duration ss: " << t.getTime() << std::endl;
+  //  }
+
+  std::string::const_iterator start = s.begin();
+  std::string::const_iterator end = s.end();
+
+  std::string s_trim;
+
+  // If it starts or ends with whitespace, trim it
+  if (*start == ' ' || *end == ' ')
+  {
+    s_trim = boost::trim_copy(s);
+    start = s_trim.begin();
+    end = s_trim.end();
+  }
+
+  bool r;
+
+  r = qi::parse(start, end, (double_ % ' '), doubleVec);
 
   return doubleVec;
 }


### PR DESCRIPTION
This is an initial joint_trajectory_action handler implementation.  It works fine but I'm sure it's not bulletproof.  I need to move on and write more docs and use the new logger.

If there are problems it can be disabled by setting ```use_rmi_driver_jta: true``` in the config.

Closes #1 