### PR TITLE
Don't clear command_list_ on eof

### DIFF
--- a/rmi_driver/include/rmi_driver/commands.h
+++ b/rmi_driver/include/rmi_driver/commands.h
@@ -47,6 +47,7 @@ struct CommandResultCodes
   {
     OK = 0,
     FAILED_TO_FIND_HANDLER = 1,
+    SOCKET_FAILED_TO_CONNECT = 2,
     ABORT_FAIL = 9998,
     ABORT_OK = 9999,
 

--- a/rmi_driver/include/rmi_driver/connector.h
+++ b/rmi_driver/include/rmi_driver/connector.h
@@ -265,7 +265,7 @@ protected:
   boost::asio::io_service& io_service_;
 
   /// Queue of all rmi_driver::RobotCommands to be sent by Connector::cmdThread().
-  std::queue<RobotCommandPtr> command_list_;
+  std::deque<RobotCommandPtr> command_list_;
 
   /// Receives the robot_movement_interface/CommandList for this namespace
   ros::Subscriber command_list_sub_;

--- a/rmi_driver/src/connector.cpp
+++ b/rmi_driver/src/connector.cpp
@@ -162,12 +162,14 @@ bool Connector::connectSocket(std::string host, int port, RobotCommand::CommandT
 
         if (ec)  // If it failed, try again
         {
-          logger_.WARN() << "Socket(" << con_type << ") Ec was set " << ec.message();
+          logger_.ERROR() << "Socket(" << con_type << ") Ec was set " << ec.message();
 
           if (command_list_.size() > 0 && cmd_type == RobotCommand::CommandType::Cmd)
           {
+            publishRmiResult(command_list_.front()->getCommandId(), CommandResultCodes::SOCKET_FAILED_TO_CONNECT,
+                             "Cmd socket failed to connect, clearing commands");
             clearCommands();
-            logger_.WARN() << "Clearing command list because the socket failed to connect while commands were waiting";
+            logger_.ERROR() << "Clearing command list because the socket failed to connect while commands were waiting";
           }
 
           std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -474,7 +476,7 @@ void Connector::publishRmiResult(int command_id, int result_code, std::string ad
   result.additional_information = additional_information;
   result.header.stamp = ros::Time::now();
 
-  command_result_pub_.publish(result);
+  publishRmiResult(result);
 }
 
 void Connector::publishRmiResult(const robot_movement_interface::Result &result) const

--- a/rmi_driver/src/connector.cpp
+++ b/rmi_driver/src/connector.cpp
@@ -352,7 +352,7 @@ void Connector::addCommand(RobotCommandPtr command)
   if (command->getType() == RobotCommand::CommandType::Cmd)
   {
     command_list_mutex_.lock();
-    command_list_.push(command);
+    command_list_.push_back(command);
     command_list_mutex_.unlock();
   }
   else
@@ -365,7 +365,7 @@ void Connector::clearCommands()
 {
   command_list_mutex_.lock();
   logger_.INFO() << "Connector::clearCommands clearing " << command_list_.size() << " entries";
-  command_list_ = std::queue<RobotCommandPtr>();
+  command_list_ = std::deque<RobotCommandPtr>();
   command_list_mutex_.unlock();
 }
 
@@ -677,7 +677,7 @@ void Connector::cmdThread()
         // Command was sent and responded to in some way.  Lock n' pop.
         command_list_mutex_.lock();
         if (command_list_.size() > 0)
-          command_list_.pop();
+          command_list_.pop_front();
         command_list_mutex_.unlock();
 
         result.additional_information = response;


### PR DESCRIPTION
If cmdThread gets a boost::asio::error::eof exception, it will not clear the command_list_ before launching connectSocket.  If connectSocket is successful, it relaunches cmdThread and the command_list_ will be handled.  If connectSocket fails to reconnect, the command_list_ will be cleared and a fail result published.

Closes #5 